### PR TITLE
Dev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hc-vault"
 description = "A simple crate to interact with hashicorp's vault"
 repository = "https://github.com/Lol3rrr/hc-vault"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["lol3rrr <s.loler03@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/src/approle.rs
+++ b/src/approle.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::time::{Duration, Instant};
+use std::time::Instant;
 use url::Url;
 
 use crate::Auth as AuthTrait;
@@ -48,19 +48,32 @@ struct ApproleResponse {
 pub struct Session {
     approle: ApproleLogin,
 
-    token: String,
-    token_start: Instant,
-    token_duration: Duration,
+    token: std::sync::atomic::AtomicPtr<String>,
+    /// The Start time in seconds
+    token_start: std::sync::atomic::AtomicU64,
+    /// The duration in seconds
+    token_duration: std::sync::atomic::AtomicU64,
 }
 
 impl AuthTrait for Session {
     fn is_expired(&self) -> bool {
-        self.token_start.elapsed() >= self.token_duration
+        let start_time = self.token_start.load(std::sync::atomic::Ordering::SeqCst);
+        let current_time = Instant::now().elapsed().as_secs();
+        let elapsed = current_time - start_time;
+        let duration = self
+            .token_duration
+            .load(std::sync::atomic::Ordering::SeqCst);
+
+        elapsed >= duration
     }
     fn get_token(&self) -> String {
-        self.token.clone()
+        let token = self.token.load(std::sync::atomic::Ordering::SeqCst);
+        match unsafe { token.as_ref() } {
+            None => String::from(""),
+            Some(s) => s.clone(),
+        }
     }
-    fn auth(&mut self, vault_url: &str) -> Result<(), Error> {
+    fn auth(&self, vault_url: &str) -> Result<(), Error> {
         let mut login_url = match Url::parse(vault_url) {
             Err(e) => {
                 return Err(Error::from(e));
@@ -108,9 +121,22 @@ impl AuthTrait for Session {
 
         let data = data.unwrap();
 
-        self.token = data.auth.client_token;
-        self.token_start = Instant::now();
-        self.token_duration = Duration::from_secs(data.auth.lease_duration);
+        let token = data.auth.client_token;
+        let current_time = Instant::now().elapsed().as_secs();
+        let duration = data.auth.lease_duration;
+
+        let boxed_token = Box::new(token.clone());
+
+        let old_token_ptr = self.token.swap(
+            Box::into_raw(boxed_token),
+            std::sync::atomic::Ordering::SeqCst,
+        );
+        self.token_start
+            .store(current_time, std::sync::atomic::Ordering::SeqCst);
+        self.token_duration
+            .store(duration, std::sync::atomic::Ordering::SeqCst);
+
+        std::mem::drop(old_token_ptr);
 
         Ok(())
     }
@@ -124,9 +150,9 @@ impl Session {
 
         Ok(Session {
             approle,
-            token: "".to_string(),
-            token_start: Instant::now(),
-            token_duration: Duration::from_secs(0),
+            token: std::sync::atomic::AtomicPtr::new(&mut String::from("")),
+            token_start: std::sync::atomic::AtomicU64::new(0),
+            token_duration: std::sync::atomic::AtomicU64::new(0),
         })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ pub trait Auth {
     fn is_expired(&self) -> bool;
     /// Used to actually authenticate with the backend and obain a new valid session
     /// that can be used for further requests to vault
-    fn auth(&mut self, vault_url: &str) -> Result<(), Error>;
+    fn auth(&self, vault_url: &str) -> Result<(), Error>;
     /// Returns the vault token that can be used to make requests to vault
     /// as the current session
     fn get_token(&self) -> String;
@@ -122,36 +122,60 @@ impl Default for Config {
 /// further requests to vault
 pub struct Client<T: Auth> {
     config: Config,
-    auth: std::sync::Mutex<T>,
+    auth: T,
+    reauth_mutex: std::sync::Mutex<()>,
 }
 
 impl<T: Auth> Client<T> {
     /// This function is used to obtain a new vault session with the given config and
     /// auth settings
-    pub async fn new(conf: Config, auth_opts: T) -> Result<Client<T>, Error> {
-        let auth_mutex = std::sync::Mutex::new(auth_opts);
-
-        match auth_mutex.lock().unwrap().auth(&conf.vault_url) {
+    pub fn new(conf: Config, auth_opts: T) -> Result<Client<T>, Error> {
+        match auth_opts.auth(&conf.vault_url) {
             Err(e) => return Err(e),
             Ok(()) => {}
         };
 
         Ok(Client::<T> {
             config: conf,
-            auth: auth_mutex,
+            auth: auth_opts,
+            reauth_mutex: std::sync::Mutex::new(()),
         })
     }
 
-    async fn check_session(&self) -> Result<(), Error> {
-        let mut auth = self.auth.lock().unwrap();
+    /// A simple method to get the underlying vault session/client token
+    /// for the current vault session.
+    /// It is not recommended to use this function, but rather stick to other
+    /// more integrated parts, like the vault_request function
+    pub fn get_token(&self) -> String {
+        self.auth.get_token()
+    }
 
-        if !auth.is_expired() {
+    /// This function is used to check if the current
+    /// session is still valid and if not to renew
+    /// the session/obtain a new one and update
+    /// all data related to it
+    pub async fn check_session(&self) -> Result<(), Error> {
+        if !self.auth.is_expired() {
             return Ok(());
         }
-        match self.config.renew_policy {
-            RenewPolicy::Reauth => auth.auth(&self.config.vault_url),
-            RenewPolicy::Nothing => Err(Error::SessionExpired),
+
+        // Take mutex to ensure only one thread can try to reauth at a time
+        let _data = self.reauth_mutex.lock().unwrap();
+        // If the mutex is acquired, check if the session still needs to be renewed or if another
+        // thread has already done this, in which case this one should just return as its all fine
+        // now
+        if !self.auth.is_expired() {
+            return Ok(());
         }
+
+        let result = match self.config.renew_policy {
+            RenewPolicy::Reauth => self.auth.auth(&self.config.vault_url),
+            RenewPolicy::Nothing => Err(Error::SessionExpired),
+        };
+
+        println!("New Token: {}", self.auth.get_token());
+
+        return result;
     }
 
     /// This function is a general way to directly make requests to vault using
@@ -184,11 +208,7 @@ impl<T: Auth> Client<T> {
             Ok(u) => u,
         };
 
-        let token;
-        {
-            let auth = self.auth.lock().unwrap();
-            token = auth.get_token();
-        }
+        let token = self.auth.get_token();
 
         let http_client = reqwest::Client::new();
         let mut req = http_client

--- a/src/token.rs
+++ b/src/token.rs
@@ -18,7 +18,7 @@ impl AuthTrait for Session {
     fn get_token(&self) -> String {
         self.token.clone()
     }
-    fn auth(&mut self, _vault_url: &str) -> Result<(), Error> {
+    fn auth(&self, _vault_url: &str) -> Result<(), Error> {
         Ok(())
     }
 }

--- a/tests/approle/auth.rs
+++ b/tests/approle/auth.rs
@@ -62,7 +62,7 @@ fn valid_new_approle() {
             .mount(&mock_server),
     );
 
-    let mut tmp_auth = match hc_vault::approle::Session::new(test_role_id, test_secret_id) {
+    let tmp_auth = match hc_vault::approle::Session::new(test_role_id, test_secret_id) {
         Err(e) => {
             assert!(false, "Should not return error: '{}'", e);
             return;
@@ -98,7 +98,7 @@ fn invalid_new_approle_not_found() {
             .mount(&mock_server),
     );
 
-    let mut tmp_auth = match hc_vault::approle::Session::new(test_role_id, test_secret_id) {
+    let tmp_auth = match hc_vault::approle::Session::new(test_role_id, test_secret_id) {
         Err(e) => {
             assert!(false, "Should not return error: '{}'", e);
             return;
@@ -134,7 +134,7 @@ fn invalid_new_approle_not_valid_403() {
             .mount(&mock_server),
     );
 
-    let mut tmp_auth = match hc_vault::approle::Session::new(test_role_id, test_secret_id) {
+    let tmp_auth = match hc_vault::approle::Session::new(test_role_id, test_secret_id) {
         Err(e) => {
             assert!(false, "Should not return error: '{}'", e);
             return;

--- a/tests/database/get_credentials.rs
+++ b/tests/database/get_credentials.rs
@@ -42,7 +42,7 @@ async fn valid_get_credentials() {
         vault_url: mock_server.uri().clone(),
         ..Default::default()
     };
-    let mut client = match hc_vault::Client::new(conf, auth).await {
+    let mut client = match hc_vault::Client::new(conf, auth) {
         Err(e) => {
             assert!(false, "Should not return error: '{}'", e);
             return;

--- a/tests/general/reauth.rs
+++ b/tests/general/reauth.rs
@@ -1,0 +1,134 @@
+extern crate hc_vault;
+
+use async_std::task;
+
+use wiremock::matchers::{body_json, header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use serde::Serialize;
+use serde_json::json;
+
+#[derive(Serialize)]
+struct ApproleAuthResponse {
+    renewable: bool,
+    lease_duration: u64,
+    token_policies: Vec<String>,
+    accessor: String,
+    client_token: String,
+}
+
+#[derive(Serialize)]
+struct ApproleResponse {
+    auth: ApproleAuthResponse,
+    lease_duration: u64,
+    renewable: bool,
+    lease_id: String,
+}
+
+#[test]
+fn valid_auth_from_multiple_threads() {
+    let mock_server = task::block_on(MockServer::start());
+
+    let test_role_id = "testID".to_string();
+    let test_secret_id = "testSecret".to_string();
+
+    let expected_body = json!({
+        "role_id": test_role_id.clone(),
+        "secret_id": test_secret_id.clone(),
+    });
+
+    let first_response = ResponseTemplate::new(200).set_body_json(ApproleResponse {
+        auth: ApproleAuthResponse {
+            renewable: true,
+            lease_duration: 0,
+            token_policies: vec!["test".to_string()],
+            accessor: "testAccessor".to_string(),
+            client_token: "testToken".to_string(),
+        },
+        lease_duration: 0,
+        renewable: false,
+        lease_id: "".to_string(),
+    });
+
+    task::block_on(
+        Mock::given(method("POST"))
+            .and(path("/v1/auth/approle/login"))
+            .and(body_json(&expected_body))
+            .respond_with(first_response)
+            .expect(1)
+            .mount(&mock_server),
+    );
+
+    let tmp_auth = match hc_vault::approle::Session::new(test_role_id, test_secret_id) {
+        Err(e) => {
+            assert!(false, "Should not return error: '{}'", e);
+            return;
+        }
+        Ok(s) => s,
+    };
+
+    println!("Before client");
+
+    let config = hc_vault::Config {
+        vault_url: mock_server.uri(),
+        ..Default::default()
+    };
+    let tmp_client = match hc_vault::Client::new(config, tmp_auth) {
+        Err(e) => {
+            assert!(false, "Should not return error: {}", e);
+            return;
+        }
+        Ok(s) => s,
+    };
+
+    println!("After client");
+
+    task::block_on(mock_server.reset());
+
+    let second_response = ResponseTemplate::new(200).set_body_json(ApproleResponse {
+        auth: ApproleAuthResponse {
+            renewable: true,
+            lease_duration: 120,
+            token_policies: vec!["test".to_string()],
+            accessor: "testAccessor".to_string(),
+            client_token: "concurrentToken".to_string(),
+        },
+        lease_duration: 0,
+        renewable: false,
+        lease_id: "".to_string(),
+    });
+
+    task::block_on(
+        Mock::given(method("POST"))
+            .and(path("/v1/auth/approle/login"))
+            .respond_with(second_response)
+            .expect(1)
+            .mount(&mock_server),
+    );
+
+    let client_arc = std::sync::Arc::new(tmp_client);
+    let barrier = std::sync::Arc::new(std::sync::Barrier::new(5));
+    let done_barrier = std::sync::Arc::new(std::sync::Barrier::new(6));
+
+    for _ in 0..5 {
+        let c = std::sync::Arc::clone(&barrier);
+        let c_client = std::sync::Arc::clone(&client_arc);
+        let c_done = std::sync::Arc::clone(&done_barrier);
+
+        std::thread::spawn(move || {
+            c.wait();
+            match task::block_on(c_client.check_session()) {
+                Err(e) => {
+                    assert!(false, "Should not return error {}", e);
+                }
+                Ok(_) => {}
+            };
+
+            c_done.wait();
+        });
+    }
+
+    done_barrier.wait();
+
+    assert_eq!(client_arc.get_token(), String::from("concurrentToken"));
+}

--- a/tests/general/reauth.rs
+++ b/tests/general/reauth.rs
@@ -2,7 +2,7 @@ extern crate hc_vault;
 
 use async_std::task;
 
-use wiremock::matchers::{body_json, header, method, path};
+use wiremock::matchers::{body_json, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use serde::Serialize;

--- a/tests/general/vault_request.rs
+++ b/tests/general/vault_request.rs
@@ -30,7 +30,7 @@ async fn valid_vault_request_no_body() {
         vault_url: mock_server.uri().clone(),
         ..Default::default()
     };
-    let client = match hc_vault::Client::new(conf, auth).await {
+    let client = match hc_vault::Client::new(conf, auth) {
         Err(e) => {
             assert!(false, "Should not return error: {}", e);
             return;
@@ -79,7 +79,7 @@ async fn valid_vault_request_with_body() {
         vault_url: mock_server.uri().clone(),
         ..Default::default()
     };
-    let client = match hc_vault::Client::new(conf, auth).await {
+    let client = match hc_vault::Client::new(conf, auth) {
         Err(e) => {
             assert!(false, "Should not return error: {}", e);
             return;

--- a/tests/kv2/configure.rs
+++ b/tests/kv2/configure.rs
@@ -35,7 +35,7 @@ async fn valid_configure_no_options() {
         vault_url: mock_server.uri().clone(),
         ..Default::default()
     };
-    let client = match hc_vault::Client::new(conf, auth).await {
+    let client = match hc_vault::Client::new(conf, auth) {
         Err(e) => {
             assert!(false, "Should not return error: '{}'", e);
             return;
@@ -84,7 +84,7 @@ async fn valid_configure_only_max_verison_option() {
         vault_url: mock_server.uri().clone(),
         ..Default::default()
     };
-    let client = match hc_vault::Client::new(conf, auth).await {
+    let client = match hc_vault::Client::new(conf, auth) {
         Err(e) => {
             assert!(false, "Should not return error: '{}'", e);
             return;
@@ -133,7 +133,7 @@ async fn valid_configure_only_cas_required_option() {
         vault_url: mock_server.uri().clone(),
         ..Default::default()
     };
-    let client = match hc_vault::Client::new(conf, auth).await {
+    let client = match hc_vault::Client::new(conf, auth) {
         Err(e) => {
             assert!(false, "Should not return error: '{}'", e);
             return;
@@ -182,7 +182,7 @@ async fn valid_configure_only_delete_version_after_option() {
         vault_url: mock_server.uri().clone(),
         ..Default::default()
     };
-    let client = match hc_vault::Client::new(conf, auth).await {
+    let client = match hc_vault::Client::new(conf, auth) {
         Err(e) => {
             assert!(false, "Should not return error: '{}'", e);
             return;
@@ -233,7 +233,7 @@ async fn valid_configure_all_options() {
         vault_url: mock_server.uri().clone(),
         ..Default::default()
     };
-    let client = match hc_vault::Client::new(conf, auth).await {
+    let client = match hc_vault::Client::new(conf, auth) {
         Err(e) => {
             assert!(false, "Should not return error: '{}'", e);
             return;

--- a/tests/kv2/delete.rs
+++ b/tests/kv2/delete.rs
@@ -25,7 +25,7 @@ async fn valid_delete() {
         vault_url: mock_server.uri().clone(),
         ..Default::default()
     };
-    let client = match hc_vault::Client::new(conf, auth).await {
+    let client = match hc_vault::Client::new(conf, auth) {
         Err(e) => {
             assert!(false, "Should not return error: '{}'", e);
             return;

--- a/tests/kv2/delete_metadata_all_versions.rs
+++ b/tests/kv2/delete_metadata_all_versions.rs
@@ -25,7 +25,7 @@ async fn valid_delete_metadata_all_versions() {
         vault_url: mock_server.uri().clone(),
         ..Default::default()
     };
-    let client = match hc_vault::Client::new(conf, auth).await {
+    let client = match hc_vault::Client::new(conf, auth) {
         Err(e) => {
             assert!(false, "Should not return error: '{}'", e);
             return;

--- a/tests/kv2/delete_versions.rs
+++ b/tests/kv2/delete_versions.rs
@@ -33,7 +33,7 @@ async fn valid_delete_versions() {
         vault_url: mock_server.uri().clone(),
         ..Default::default()
     };
-    let client = match hc_vault::Client::new(conf, auth).await {
+    let client = match hc_vault::Client::new(conf, auth) {
         Err(e) => {
             assert!(false, "Should not return error: '{}'", e);
             return;

--- a/tests/kv2/destroy_versions.rs
+++ b/tests/kv2/destroy_versions.rs
@@ -33,7 +33,7 @@ async fn valid_destroy_versions() {
         vault_url: mock_server.uri().clone(),
         ..Default::default()
     };
-    let client = match hc_vault::Client::new(conf, auth).await {
+    let client = match hc_vault::Client::new(conf, auth) {
         Err(e) => {
             assert!(false, "Should not return error: '{}'", e);
             return;

--- a/tests/kv2/get.rs
+++ b/tests/kv2/get.rs
@@ -56,7 +56,7 @@ async fn valid_get_no_version() {
         vault_url: mock_server.uri().clone(),
         ..Default::default()
     };
-    let client = match hc_vault::Client::new(conf, auth).await {
+    let client = match hc_vault::Client::new(conf, auth) {
         Err(e) => {
             assert!(false, "Should not return error: '{}'", e);
             return;
@@ -104,7 +104,7 @@ async fn valid_get_version() {
         vault_url: mock_server.uri().clone(),
         ..Default::default()
     };
-    let client = match hc_vault::Client::new(conf, auth).await {
+    let client = match hc_vault::Client::new(conf, auth) {
         Err(e) => {
             assert!(false, "Should not return error: '{}'", e);
             return;

--- a/tests/kv2/get_configuration.rs
+++ b/tests/kv2/get_configuration.rs
@@ -35,7 +35,7 @@ async fn valid_get_no_configuration() {
         vault_url: mock_server.uri().clone(),
         ..Default::default()
     };
-    let client = match hc_vault::Client::new(conf, auth).await {
+    let client = match hc_vault::Client::new(conf, auth) {
         Err(e) => {
             assert!(false, "Should not return error: '{}'", e);
             return;
@@ -82,7 +82,7 @@ async fn valid_get_all_configuration() {
         vault_url: mock_server.uri().clone(),
         ..Default::default()
     };
-    let client = match hc_vault::Client::new(conf, auth).await {
+    let client = match hc_vault::Client::new(conf, auth) {
         Err(e) => {
             assert!(false, "Should not return error: '{}'", e);
             return;

--- a/tests/kv2/undelete_versions.rs
+++ b/tests/kv2/undelete_versions.rs
@@ -33,7 +33,7 @@ async fn valid_undelete_versions() {
         vault_url: mock_server.uri().clone(),
         ..Default::default()
     };
-    let client = match hc_vault::Client::new(conf, auth).await {
+    let client = match hc_vault::Client::new(conf, auth) {
         Err(e) => {
             assert!(false, "Should not return error: '{}'", e);
             return;

--- a/tests/kv2/update_set.rs
+++ b/tests/kv2/update_set.rs
@@ -35,7 +35,7 @@ async fn valid_update_set_no_options() {
         vault_url: mock_server.uri().clone(),
         ..Default::default()
     };
-    let client = match hc_vault::Client::new(conf, auth).await {
+    let client = match hc_vault::Client::new(conf, auth) {
         Err(e) => {
             assert!(false, "Should not return error: '{}'", e);
             return;
@@ -86,7 +86,7 @@ async fn valid_update_set_with_options() {
         vault_url: mock_server.uri().clone(),
         ..Default::default()
     };
-    let client = match hc_vault::Client::new(conf, auth).await {
+    let client = match hc_vault::Client::new(conf, auth) {
         Err(e) => {
             assert!(false, "Should not return error: '{}'", e);
             return;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -7,6 +7,7 @@ mod database {
 }
 
 mod general {
+    mod reauth;
     mod vault_request;
 }
 


### PR DESCRIPTION
Made some changes to the Auth trait that allows for better concurrency usage, because no more &mut are needed.
All the state is managed by the auth backend, which can choose how this is actually implemented internally.

General:
There is only a single mutex left in the library itself, which is used to ensure that only one thread is renewing the auth session and the rest of the threads also wait for that to finish.

Approle:
The approle auth-backend is now using atomics to manage its internal state. This makes the code itself more performant and helps to avoid blocking when it is actually not needed and also solves some of the annoying problems, like having to take a mutex just for checking a session is expired.